### PR TITLE
fix: add necessary secrets to gh release tests

### DIFF
--- a/.github/workflows/gh-release.yaml
+++ b/.github/workflows/gh-release.yaml
@@ -9,6 +9,8 @@ jobs:
   test:
     name: Run Tests
     uses: ./.github/workflows/tests.yaml
+    secrets:
+      CHACI_TEST_TOKEN: ${{ secrets.CHACI_TEST_TOKEN }}
 
   release:
     name: Build and Draft Release


### PR DESCRIPTION
Release fails as the integration tests need secrets. This PR adds those to the workflow